### PR TITLE
HeadingRule namespace fix

### DIFF
--- a/project/dexter-cs/DexterCRC/Src/Crc/HeadingCRC.cs
+++ b/project/dexter-cs/DexterCRC/Src/Crc/HeadingCRC.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace DexterCRC.Src.Crc
+namespace DexterCRC
 {
     class HeadingCRC : ICRCLogic
     {


### PR DESCRIPTION
Fixed the namespace of HeadingRule which previously prevented the analysis from running properly