### PR TITLE
Boolean property prefixing

### DIFF
--- a/project/dexter-cs/DexterCRC/DexterCRC.csproj
+++ b/project/dexter-cs/DexterCRC/DexterCRC.csproj
@@ -132,6 +132,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Src\CheckerLogic\BooleanPropertyPrefixing.cs" />
     <Compile Include="Src\CheckerLogic\VerbNaming.cs" />
     <Compile Include="Src\CheckerLogic\NounNaming.cs" />
     <Compile Include="Src\CheckerLogic\CommentRules.cs" />

--- a/project/dexter-cs/DexterCRC/Src/CheckerLogic/CommentRules.cs
+++ b/project/dexter-cs/DexterCRC/Src/CheckerLogic/CommentRules.cs
@@ -29,7 +29,7 @@ using DexterCS;
 using Microsoft.CodeAnalysis.CSharp;
 using System;
 
-namespace DexterCRC.Src.CheckerLogic
+namespace DexterCRC
 {
     public class CommentRules : ICheckerLogic
     {

--- a/project/dexter-cs/DexterCRC/Src/CheckerLogic/HeadingRule.cs
+++ b/project/dexter-cs/DexterCRC/Src/CheckerLogic/HeadingRule.cs
@@ -30,7 +30,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using System.Linq;
 
-namespace DexterCRC.Src.CheckerLogic
+namespace DexterCRC
 {
     public class HeadingRule : ICheckerLogic
     {

--- a/project/dexter-cs/DexterCRC/Src/CheckerLogic/MethodSpacing.cs
+++ b/project/dexter-cs/DexterCRC/Src/CheckerLogic/MethodSpacing.cs
@@ -30,7 +30,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using System.Linq;
 
-namespace DexterCRC.Src.CheckerLogic
+namespace DexterCRC
 {
     public class MethodSpacing : ICheckerLogic
     {

--- a/project/dexter-cs/DexterCRC/Src/Crc/CommentCRC.cs
+++ b/project/dexter-cs/DexterCRC/Src/Crc/CommentCRC.cs
@@ -25,7 +25,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
-using DexterCRC.Src.CheckerLogic;
 using DexterCS;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/project/dexter-cs/DexterCRC/Src/Crc/HeadingCRC.cs
+++ b/project/dexter-cs/DexterCRC/Src/Crc/HeadingCRC.cs
@@ -25,7 +25,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
-using DexterCRC.Src.CheckerLogic;
 using DexterCS;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/project/dexter-cs/DexterCRC/Src/Crc/SpacingCRC.cs
+++ b/project/dexter-cs/DexterCRC/Src/Crc/SpacingCRC.cs
@@ -25,7 +25,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
-using DexterCRC.Src.CheckerLogic;
 using DexterCS;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/project/dexter-cs/DexterCS/Src/Util/DexterUtil.cs
+++ b/project/dexter-cs/DexterCS/Src/Util/DexterUtil.cs
@@ -26,6 +26,7 @@
  */
 #endregion
 using log4net;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -73,6 +74,11 @@ namespace DexterCS
             {
                 return Path.AltDirectorySeparatorChar.ToString();
             }
+        }
+
+        public static bool IsPropertyDeclarationBoolean(PropertyDeclarationSyntax propertyRaw)
+        {
+            return propertyRaw.Type.ToString() == "bool" || propertyRaw.Type.ToString() == "boolean";
         }
 
         private static string dateFormat = "yyyyMMddHHmmss";

--- a/project/dexter-cs/DexterCSTest/Src/CheckerLogic/HeadingRuleTest.cs
+++ b/project/dexter-cs/DexterCSTest/Src/CheckerLogic/HeadingRuleTest.cs
@@ -25,7 +25,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #endregion
-using DexterCRC.Src.CheckerLogic;
+using DexterCRC;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DexterCSTest.Src.CRCLogic
@@ -50,7 +50,7 @@ namespace DexterCSTest.Src.CRCLogic
                                   using System.Text;
                                   using System.Threading.Tasks;
 
-                                            namespace DexterCRC.Src.CheckerLogic
+                                            namespace DexterCRC
                                                                             {
                                                  public class SampleClass {";
             //when
@@ -82,7 +82,7 @@ namespace DexterCSTest.Src.CRCLogic
                                   using System.Text;
                                   using System.Threading.Tasks;
 
-                                            namespace DexterCRC.Src.CheckerLogic
+                                            namespace DexterCRC
                                                                             {
                                                  public class SampleClass {";
             //when


### PR DESCRIPTION
Added rule for prefixing boolean properties with "is", "has", "can"
Unified namespaces of coding rules